### PR TITLE
Show account name only if it's set

### DIFF
--- a/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryHolder.java
+++ b/app/src/main/java/com/beemdevelopment/aegis/ui/views/EntryHolder.java
@@ -108,7 +108,7 @@ public class EntryHolder extends RecyclerView.ViewHolder {
 
         _profileIssuer.setText(entry.getIssuer());
         _profileName.setText("");
-        if (showAccountName) {
+        if (showAccountName && !entry.getName().isEmpty()) {
             _profileName.setText(" - " + entry.getName());
         }
 


### PR DESCRIPTION
If you set an account name to an empty string, right now you see a trailing dash, e.g. `Github - `.

This change should fix this, so that the dash is only added when account name is not empty.